### PR TITLE
Fix JSON update issue in get method

### DIFF
--- a/synaptic/meta.py
+++ b/synaptic/meta.py
@@ -261,8 +261,10 @@ class Metadata:
         # -- transient settings to overlay on top of the persistent data
         try:
             all_data.update(
-                mc.getAttr(
-                    f"{meta_name}.{_Attributes.TRANSIENT_DATA}",
+                json.loads(
+                    mc.getAttr(
+                        f"{meta_name}.{_Attributes.TRANSIENT_DATA}",
+                    ),
                 ),
             )
 


### PR DESCRIPTION
There was an issue in the `get` method where the code was directly using `data.update` on a string returned from `cmds.getAttr`. This caused an error because `update` expects a dictionary, not a string.